### PR TITLE
add missing email port attribute

### DIFF
--- a/deploy/grnet-zeus/manifests/init.pp
+++ b/deploy/grnet-zeus/manifests/init.pp
@@ -52,6 +52,7 @@ class zeus (
     $emailhost = 'localhost',
     $emailhostuser = false,
     $emailhostpass = false,
+    $emailport = 25,
     $debugemail = true,
     $dev = false
 ) {


### PR DESCRIPTION
zeus::emailport value ignored from config.yml because have missed from class definition